### PR TITLE
[MOTION] - Updating Co-OC term in the Coverall Policy

### DIFF
--- a/6.tex
+++ b/6.tex
@@ -1301,7 +1301,11 @@ that comes with wearing the coverall.
    \item
     Vice-President, External
    \item
-    Outgoing Co-Orientation Coordinators
+    Co-Orientation Coordinators
+    \begin{enumerate}
+      \item
+      Term is of their Welcome Week calendar year (January - December)
+    \end{enumerate}
    \item
     Equity, Diversity, and Inclusion Officer
   \end{enumerate}


### PR DESCRIPTION
2023-11-27
Motion -  Updating Co-OC term in the Coverall Policy

Spirit:  Coverall Oversight Committee oversees the usage of the red coveralls, ensuring the McMaster Engineering Society and the Faculty of Engineering is represented positively.
Whereas: The Coverall Policy had Outgoing Co-OCs on the policy for stability reasons over the first year of the process.
Whereas: The Coverall Policy was intended to be changed at the end of the Winter term to be the current Co-OCs.
Whereas: The Outgoing Co-OCs have requested the term be changed sooner.
Whereas: The Co-OCs have agreed to take on the responsibility at the start of January.
BIRT: The term for Co-OCs on the Coverall Oversight Committee be changed to the calendar year of the Co-OCs Welcome Week.
BIRT:The following change to the Policy Manual is accepted:

Motioned by: Nicole
Seconded by: Bryson
For: 23
Against:0
Abstain:1
Motion Result:Passed!