### PR TITLE
[MOTION] - Change Data, Sustainability, and Sports portfolios

### DIFF
--- a/1.tex
+++ b/1.tex
@@ -133,8 +133,6 @@ The Associate Vice President, Events shall:
 
   \begin{enumerate}
    \item
-    Sports Coordinator(s)
-   \item
     Fireball Coordinator(s)
    \item
     Kipling Coordinator(s)

--- a/vice-president-academic.tex
+++ b/vice-president-academic.tex
@@ -71,6 +71,8 @@ The Vice President, Academic shall:
     Mentorship Coordinator(s)
    \item
     Associate Vice President, Academic Resources
+    \item
+    Data Coordinator(s)
 
   \end{enumerate}
 \end{enumerate}

--- a/vice-president-internal.tex
+++ b/vice-president-internal.tex
@@ -64,8 +64,6 @@ The Vice President, Internal shall:
    \item
     Associate Vice-President, Clubs
    \item
-    Data Coordinator(s)
-   \item
     DW Lounge Coordinator(s)
    \item
     Gerald Hatch Centre Student Coordinator(s)
@@ -73,8 +71,6 @@ The Vice President, Internal shall:
     Information Technology Coordinator(s)
    \item
     Trailer Coordinator(s)
-   \item
-    Sustainability Coordinator(s)
 
   \end{enumerate}
 \end{enumerate}

--- a/vice-president-student-life.tex
+++ b/vice-president-student-life.tex
@@ -68,6 +68,10 @@ The Vice President, Student Life shall:
     Bus Monitor Lead
    \item
     First Year Representatives
+   \item
+    Sports Coordinator(s)
+   \item
+    Sustainability Coordinator(s)
   \end{enumerate}
  \item
   Develop protocols, with any members at the VPSL's discretion, for the


### PR DESCRIPTION
First Reading - Changing Portfolios 

Motion - Changing Portfolios
Made by: Luke Schuurman

Spirit: Ensuring relevant oversight of appointed positions and balancing of executive portfolios helps the Society operate better.
Whereas: The Executive and AVPs have agreed to some long-term portfolio changes.
BIRT: Sustainability Coordinator(s) be moved from VP Internal portfolio to VP Student Life portfolio
BIFRT: Sports Coordinator(s) be moved from AVP Events portfolio to VP Student Life portfolio
BIFRT: Data Coordinator(s) be moved from VP Internal portfolio to VP Student Life portfolio

Amendment of agenda so Data Co-ordinators get moved to VP Academic→ {1st - Luke ; 2nd - Simone} → Passed/ Failed (?)
For: 20
Against: 1
Abstain: 1

Motion - Changing Portfolios
Motioned by: Luke
Seconded by: Alexis
For: 18
Against: 2
Abstain:2
Motion Result: Passed!
