### PR TITLE
[MOTION] - Add unanimous consent, consent agenda, and temporary chair to Council Meeting policy

### DIFF
--- a/3.tex
+++ b/3.tex
@@ -927,7 +927,8 @@ By-Laws document for details.
        not pass the chair except when returning it to the Chair.
      \end{enumerate}
     \item
-     The Chair must reassume their role upon a majority vote.
+    The Chair automatically reassumes their role upon the conclusion of
+    their presentation and discussion.
   \end{enumerate}
 
 \end{enumerate}


### PR DESCRIPTION

2023-11-27
First Reading - Adding to Meeting Policy

Question & Answer Process: 
Q: Mark: what does unanonymous consent in this context mean? 
Luke: This is an addition to consent agenda so rather than doing for, abstain and against it does speed up the voting for certain niche scenarios that need unanimous consent 
Luke: This is brought because various organizations such as 
Arjun: If we knew ahead of time that certain motions would need 

2024-01-16
Motion - Adding to Meeting Policy
Motioned by: Annabelle
Seconded by: Alexis
For: 19 
Against:0 
Abstain: 1
Motion Result: Passed!

Purpose: To add bylaws concerning chair changes and unanimous consent to MES Meeting Policy. 
Whereas: By updating meeting policy, MES Council Meetings can be better controlled and streamlined.
BIRT: The Council adopts the following changes to Meeting Policy within the MES Bylaws:
MES Council is permitted to use a consent agenda, where multiple items of discussion can be grouped into a single motion and vote. 
MES Council may pass motions by unanimous consent, also known as general consent, when no elected Council member objects to a motion.
The Chair is not required to pass the chair if they need to present, but must do so in the event where they are unable to moderate discussion in a proper and unbiased manner.
The Temporary Chair must:
Be an elected Council member.
Be elected by majority vote. 
Not pass the chair except when returning it to the CRO. 
The Chair must reassume their role upon a majority vote. 

Question & Answer Process: 
Q: Luke: Does the elected council member still be able to vote as temporary chair?
A: Annabelle: I’d assume that the elected council member would not be able to vote.
Arjun: So when does the CRO pass the chair?
Annabelle: I personally think it's hard to present and do chairing at the same time, so that’s mainly when I do it.
Luke: Maybe we can do it so that when a motion is passed then in that situation the chairing should be pas
Arjun: As long as the chair is passed back to CRO when the motion is being voted, it could save a lot of these changes.
