### PR TITLE
[MOTION] - Updating Fireball Awards Descriptions

### DIFF
--- a/6.tex
+++ b/6.tex
@@ -1596,9 +1596,9 @@ that comes with wearing the coverall.
     year at Fireball.
    \item
     The ``Image of an Engineer'' Award is given to an undergraduate
-    engineering student who contributes to improving the image of an
-    engineer through extracurricular, leadership, and/or community
-    activities.
+    Faculty of Engineering student who contributes to improving the
+    image of an engineer through extracurricular, leadership, and/or
+    community activities.
   \end{enumerate}
  \item
   Faculty Appreciation Award
@@ -1610,8 +1610,8 @@ that comes with wearing the coverall.
    \item
     The Faculty Appreciation Award is given to a faculty or staff member
     within the Faculty of Engineering, to recognize a significant
-    contribution outside of the classroom to the undergraduate
-    engineering students at McMaster University.
+    contribution outside of the classroom to the undergraduate Faculty
+    of Engineering students at McMaster University.
   \end{enumerate}
  \item
   Outstanding Teaching Assistant Award
@@ -1622,9 +1622,9 @@ that comes with wearing the coverall.
     each year at Fireball.
    \item
     The Outstanding Teaching Assistant Award is given to a Teaching
-    Assistant, of an engineering course, who has gone above and beyond
-    in order to provide an engaging learning environment for their
-    students.
+    Assistant, of a Faculty of Engineering course, who has gone above
+    and beyond in order to provide an engaging learning environment for
+    their students.
   \end{enumerate}
  \item
   President's Award


### PR DESCRIPTION
2024-01-16
Motion - Updating Fireball Awards Descriptions
Motioned by: Annabelle
Seconded by: Armina
For: 19
Against: 0
Abstain: 0
Motion Result: Passed!
 
Purpose: To update the descriptions of the Fireball Awards to better represent the Faculty of Engineering.
Whereas: The current descriptions only suggest "engineering" students may win the awards, not "Faculty of Engineering" students.
MES Needs to:
BIRT: Accept the following changes to be made to the policy manual:
The “Image of an Engineer”, Faculty Appreciation Award and Outstanding Teaching Assistant Award adjust their description to state “undergraduate Faculty of Engineering” rather than just “undergraduate engineering”

Question & Answer Process: 
Q: Daksh: What is the difference between the changing the phrasing, it seems kind of assumed?
A: Annabelle: In the past members of B-tech have been nominated, but I want the phrasing to be clearly stated to ensure there is no confusion in the future.
