### PR TITLE
Updates to the Coverall Policy

### DIFF
--- a/6.tex
+++ b/6.tex
@@ -14,7 +14,7 @@
 
 \hypertarget{interintra-university-liaison}{%
  \section{INTER/INTRA UNIVERSITY
-  LIAISON}
+   LIAISON}
  \label{interintra-university-liaison}}
 
 \hypertarget{hosted-conferences-and-competitions}{%
@@ -1323,32 +1323,44 @@ The Vice-President, External is responsible for:
  \item
   Overseeing and being ultimately responsible for the coveralls.
  \item
-  Track the inventory of coveralls and organize future orders of coveralls.
+  Track the inventory of coveralls and organize future orders of
+  coveralls.
  \item
-  Collaborate with the Drain Coordinators on the purchase and distribution of coveralls.
+  Collaborate with the Drain Coordinators on the purchase and
+  distribution of coveralls.
  \item
-  Coordinating sizing, pick-up, and payment with approved applicants during regular Drain operating hours in order for the Drain volunteers to facilitate payment.
+  Coordinating sizing, pick-up, and payment with approved applicants
+  during regular Drain operating hours in order for the Drain volunteers
+  to facilitate payment.
  \item
-  Maintaining and updating the Coverall Sponsor, Coverall Event, and Coverall Application forms.
+  Maintaining and updating the Coverall Sponsor, Coverall Event, and
+  Coverall Application forms.
  \item
-  Collecting a list of individuals attending the Coverall Event from the Coverall Sponsor.
+  Collecting a list of individuals attending the Coverall Event from the
+  Coverall Sponsor.
  \item
-  Ensuring the voting members of the Coverall Oversight Committee review applications on a regular basis.
+  Ensuring the voting members of the Coverall Oversight Committee review
+  applications on a regular basis.
  \item
-  Communicating application status with Coverall Sponsors and the application status of their Coverall Event(s).
+  Communicating application status with Coverall Sponsors and the
+  application status of their Coverall Event(s).
  \item
-  Maintaining a list of club executives, vetting the eligibility of Coverall Sponsor applicants, and acting as the Coverall Sponsor for Student Organization leadership.
+  Maintaining a list of club executives, vetting the eligibility of
+  Coverall Sponsor applicants, and acting as the Coverall Sponsor for
+  Student Organization leadership.
  \item
   Communicating application status with Coverall Applicants.
  \item
-  Oversee the Chair and delegate responsibilities to the Chair at their discretion.
+  Oversee the Chair and delegate responsibilities to the Chair at their
+  discretion.
 \end{enumerate}
 \item
 The Chair is responsible for:
 \begin{enumerate}
  \item
   Organizing meetings to further discuss applications, where necessary.
- \item Executing responsibilities as delegated by the Vice-President, External.
+ \item Executing responsibilities as delegated by the Vice-President,
+  External.
 \end{enumerate}
 
 \hypertarget{coverall-sponsors}{%


### PR DESCRIPTION
Motion - Updates to the Coverall Policy
Motioned by: Luke
Seconded by: Simone
For: 18
Against: 0
Abstain: 1
Motion Result: Passed
Purpose: To make the coverall process clearer and enshrine the responsibilities related to the process.
Whereas: The Coverall Policy should remain updated to reflect the best operating practices.
Whereas: There is no list of responsibilities associated with the process.
MES Needs to:
Remove the "Fire Safety" and "Slips, Trips, and Falls" trainings from the Coverall Application
Have the Coverall process be placed under the Vice-President, External portfolio
Add some clarifications and grammatical changes 

Question & Answer Process: 
Q: Amy: What qualifies as a welcome week event? 
A: Luke: In our policy manual we have a list of things that welcome week does every year, so whatever is in the policy manual would follow that.
Ansh: We have a tryout pub happening in a few weeks, so we want to make sure we are allowed to wear them.
Simone: This policy is related to purchasing a suit, rather than when you are wearing a suit. 
Arjun: Who’s portfolio is this currently under?
Simone: It is currently under AVPC, who is not an exec. The exec directly above AVPC is VPI who is not directly involved. We thought it would be better to move under VPX.