### PR TITLE
[MOTION] Update OEC Delegate Funding Policy

### DIFF
--- a/Sections/9 - Financial Policies.tex
+++ b/Sections/9 - Financial Policies.tex
@@ -331,11 +331,11 @@ by the appropriate level:
 
   \begin{enumerate}
    \item
-    The MES will fund the registration and transportation fees for MEC winners to attend the Ontario Engineering Competition, and Ontario Engineering Competition winners to attend the Canadian Engineering Competition, as organized by the McMaster Engineering Competition Chair(s).
-
+    The MES will fund the delegate and transportation fees for McMaster Engineering Competition winners to attend the Ontario Engineering Competition, and Ontario Engineering Competition winners to attend the Canadian Engineering Competition.
+   \item
+    Winners of the McMaster Engineering Competition shall remit a deposit equivalent to 50\% of the delegate fee, with reimbursement contingent upon active participation in the Ontario Engineering Competition, both in the logistical planning preceding the event and during the event itself.
     \begin{enumerate}
-     \item
-      Winners who are MES members will receive up to 100\% funding while non-MES member winners will only receive up to 50\% funding.
+     \item An exception may be granted on a financial need basis, at the discretion of the Vice President, External Relations.
     \end{enumerate}
    \item
     The McMaster Engineering Competition Chair(s) shall write an article for The Frequency and/or the MES Website to be published no later than two weeks after each competition, detailing the results of the competitions.


### PR DESCRIPTION
01-30-2024
**First Reading- Skin in the Ontario Engineering Competition**

- OEC is a large expense as we fully fund competitors to represent McMaster. It is important for these students to not take the opportunity for granted. 
- We kind of want the delegates to fund the 50% of the delegate fee and once they compete, then we reimburse them back. This way, people may care a lot more and try a lot harder than going into the competition knowing it is already fully paid so they weren’t as invested. 

**Question & Answer Process:** 
- Q: Arjun: Why did we make it upfront 50% then straight 100%?
  - A: Simone: It just would be a lot of money for some kids to pay, so it makes sense to only do 50%.
- Arjun: Are you saying that people didn’t participate properly this time around? 
  - Simone: No, they were fine. There just was a noticeable difference between people who paid to be there then people who had it fully paid going into it.
- Eddy: Is there any accommodation for someone who may not be allowed to pay that 50% upfront? Because we do fund these conferences so it isn’t a barrier for people.
  - Simone: We can probably add it to be waived and under the discretion of the VPX. Never had that issue come up so far that they can’t fund at least a portion of it.  


02-27-2024
**Second Reading- Skin in the Ontario Engineering Competition**

Spirit: OEC is a large expense as we fully fund competitors to represent McMaster. It is important for these students to not take the opportunity for granted.
Whereas: OEC fees come at a high cost to the MES to fund fully, and it is a wasted funds if sponsored competitors do not end up participating 
BIRT: The following bylaw changes are implemented

First: Luke, Second: Daniel
For: 15, Against: 1
Passed