### PR TITLE
[MOTION] Change Executive Retreat Responsibility

### DIFF
--- a/Sections/1 - Structure and Organization.tex
+++ b/Sections/1 - Structure and Organization.tex
@@ -292,7 +292,7 @@ The Associate Vice President, Academic Resources shall:
 \begin{enumerate}
  \item
   The outgoing and incoming Executive shall plan and attend a retreat to make long term plans for the year ahead and carry out a more detailed transition.
-  \item
+ \item
   The President is to organize, plan and document the retreat.
  \item
   The budget for this retreat shall be set for no more than \$2000, taken from the Executive Operations budget line.


### PR DESCRIPTION
01-30-2024
**First Reading - Exec Retreat Planning**
Changing the exec retreat presentation to be the following council meeting after the retreat happens
The president should set the vision and tone for what they want to see come out of Exec Retreat.

02-27-2024
**Second Reading - Exec Retreat Planning**

- Motioned by: Alexis Moutafis-Tymcio
- Spirit: The Executive Retreat is a pivotal first part of the year for the incoming executive and may set the tone for the cohesiveness and collaboration of the team for the following year.
- Whereas: 
- The VPSL is not in the role long enough and may not have the prior experience to effectively plan the retreat. 
- The President has more time during Winter Term, may have more experience and be more likely to have gone on an Exec Retreat before.
- The President should set the vision and tone for what they want to see come out of Exec Retreat.
- The President may still delegate responsibilities to the Executive regarding the planning of Exec Retreat.
- The timeline for Exec Retreat accountability is incorrect as the first Council meeting of the year happens at the end of Winter term before the Exec Retreat.
- BIRT: The timeline for Exec Retreat accountability be changed to the first Council meeting following the retreat.
- BIRT: Bylaw B.6.4.b)a) be changed from "The VPSL is to organize, plan and document the retreat." to "The President is to organize, plan and document the retreat."

Writing
Is there a point (d) still or was it removed due to Google Docs formatting?
Ya that's just Google Docs there will still be a point (d).

Unanimous Consent
Passed