### PR TITLE
[MOTION] Update Club Status

### DIFF
--- a/Sections/8 - Clubs, Groups, Teams and Affiliates.tex
+++ b/Sections/8 - Clubs, Groups, Teams and Affiliates.tex
@@ -13,7 +13,7 @@
    \item
     Bachelor of Technology Association (BTA)
    \item
-    Chem Eng Club (CEC)
+    Chemical Engineering Society (ChES)
    \item
     Civil Engineering Society (CSS)
    \item
@@ -169,8 +169,6 @@
    \item
     Autoplow, McMaster
    \item
-    Blockchain Club, McMaster
-   \item
     Concrete Canoe, McMaster
    \item
     Engineering Jazz Band, McMaster
@@ -178,8 +176,6 @@
     Engineers with Disabilities, McMaster
    \item
     Mac Quantum Club
-   \item
-    MacSmiths
    \item
     McMaster Interdisciplinary Satellite Team (MIST)
    \item


### PR DESCRIPTION
02-27-2024
**First Reading - Update of Club Status**

Spirit: The list of Clubs & Teams should remain updated and reflect the ongoing opportunities available to students.
BIRT: Chemical Engineering Club (CEC) is renamed to Chemical Engineering Society (ChES)
BIFRT: MacSmiths is removed as an MES Affiliate
BIFRT: Blockchain Club, McMaster is removed as an MES Affiliate

Blockchain
Hey, I remember them. They started last year. And I bet it was a unanimous yes on that one too. 
	MacSmiths
A matls only group under matls. They didn’t even know they were an affiliate.
I wish I could blacksmith a sword :(


03-12-2024
**Motion - Second Reading - Update of Club Status**
Motioned by: Luke
Seconded by: Arjun

Purpose:
MES Needs to:
NOTE: Council will need to vote on this matter!


Question & Answer Process: 
Q: Michael: Why are macsmiths and blockchain being removed?
A: Luke: Blockchain has not been doing anything at all this year. Macsmiths are only material students and have not done much with us.

Extend discussion -> Luke and Arjun 

Arjun: I don’t think the status of the club should be changed due to connections. If they are really passionate about it and want to stay an affiliate, they should make the change themselves and come here. 

For: 16
Against: 0
Abstain:2
Motion Result: Passed!