### PR TITLE
[MOTION] - Move PDC from VPX to VPA

### DIFF
--- a/Sections/3 - Appointed Positions.tex
+++ b/Sections/3 - Appointed Positions.tex
@@ -578,7 +578,7 @@ The Professional Development Coordinator(s) shall:
  \item
   Organize event demographic and feedback collection in collaboration with the Data Coordinator(s).
  \item
-  Report to the VPX.
+  Report to the VPA.
  \item
   Be a position held by a maximum of two people.
 

--- a/Sections/Exec Portfolios/vice-president-academic.tex
+++ b/Sections/Exec Portfolios/vice-president-academic.tex
@@ -56,6 +56,8 @@ The Vice President, Academic shall:
     Associate Vice President, Academic Resources
    \item
     Data Coordinator(s)
+   \item
+    Professional Development Coordinator(s)
 
   \end{enumerate}
 \end{enumerate}

--- a/Sections/Exec Portfolios/vice-president-external-relations.tex
+++ b/Sections/Exec Portfolios/vice-president-external-relations.tex
@@ -53,8 +53,6 @@ The Vice President, External Relations shall:
 
   \begin{enumerate}
    \item
-    Professional Development Coordinator(s)
-   \item
     Leadership Development Conference Coordinator(s)
    \item
     First Year Experiential Conference Coordinator(s)


### PR DESCRIPTION
24-06-22-EM-01

Whereas professional development is an important aspect of students' academic journey and should be supported by the academics portfolio (VPA). 
Whereas it is currently under the VPX portfolio
Be it resolved that professional development coordinator is moved from VPX to VPA (3.1.18.4)
Be it further resolved that a maximum of three people can hold the position. (3.1.18.5) 


Motioned by: Emily Attai 
Seconded by:	Jackie Fisher
Discussion:
Voting Result: 5:0:0 Passes




