### PR TITLE
[FORMAT] - Script for Latex Formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build_files/
 *.gz
+indent.log

--- a/format.sh
+++ b/format.sh
@@ -1,6 +1,5 @@
 latexindent -s -w -l format.yaml -c=build_files/ -m bylaws.tex Sections/*.tex Sect
 ions/Exec\ Portfolios/*.tex
-rm indent.log
 
 if [ $# -gt 0 ]; then
   rm bylaws.pdf


### PR DESCRIPTION
Bash script to run the `latexindent` command and prevent unnecessary files from being staged.