### PR TITLE
[MOTION] - 24-06-22 Move Sponsorship Coordinator from VPF to VPC

### DIFF
--- a/Sections/3 - Appointed Positions.tex
+++ b/Sections/3 - Appointed Positions.tex
@@ -941,7 +941,7 @@ The Sponsorship Coordinator(s) shall:
  \item
   Assist MES Clubs and Teams' sponsorship organizers in maintaining and acquiring sponsorship and corporate relationships.
  \item
-  Report to the VPF.
+  Report to the VPC.
  \item
   Be a position held by a maximum of two people.
 \end{enumerate}

--- a/Sections/Exec Portfolios/vice-president-communications.tex
+++ b/Sections/Exec Portfolios/vice-president-communications.tex
@@ -67,6 +67,8 @@ The Vice President, Communications shall:
     Website Coordinator(s)
    \item
     Photographer/Videographer(s)
+   \item
+    Sponsorship Coordinator(s)
   \end{enumerate}
 
 \end{enumerate}

--- a/Sections/Exec Portfolios/vice-president-finance.tex
+++ b/Sections/Exec Portfolios/vice-president-finance.tex
@@ -34,8 +34,6 @@ The Vice President, Finance shall:
   \begin{enumerate}
    \item
     Drain Coordinator(s)
-   \item
-    Sponsorship Coordinator(s)
 
   \end{enumerate}
 \end{enumerate}


### PR DESCRIPTION
24-06-22-EM-03

Whereas sponsorship coordinator currently falls under the purview of the VP Finance
Be it resolved that sponsorship coordinator moves to the portfolio of the VP Communications 
Motioned by:	Luke Schuurman
Seconded by: Emily Attai
Discussion:
Voting Result: 4:1:0 - VP External makes their abstention noticed.

