### PR TITLE
Update Format Script

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,6 +1,5 @@
-latexindent -s -w -l format.yaml -c=build_files/ -m bylaws.tex Sections/*.tex Sect
-ions/Exec\ Portfolios/*.tex
+latexindent -s -w -l format.yaml -c=build_files/ -m bylaws.tex Sections/*.tex Sections/Exec\ Portfolios/*.tex
 
 if [ $# -gt 0 ]; then
-  rm bylaws.pdf
+  git restore bylaws.pdf
 fi


### PR DESCRIPTION
Fix issues with the format script. Linebreak was missed and desired behaviour is to discard `bylaws.pdf` rather than delete it if the changes are unwanted.