### PR TITLE
[MOTION] 24-07-11 Remove the MESsenger

### DIFF
--- a/Sections/1 - Structure and Organization.tex
+++ b/Sections/1 - Structure and Organization.tex
@@ -224,7 +224,7 @@ The Associate Vice President, Academic Resources shall:
    \item
     To keep the MES informed of all program and program society issues and activities.
    \item
-    Advertise all MES events and activities to their respective constituents by making class announcements, distributing posters from the Graphic Designers, distributing MES publications, promoting the MES website, and MESsenger email list.
+    Advertise all MES events and activities to their respective constituents by making class announcements, distributing posters from the Graphic Designers, distributing MES publications, and promoting the MES website.
    \item
     Actively encourage participation in all MES activities.
    \item
@@ -263,7 +263,7 @@ The Associate Vice President, Academic Resources shall:
 
   \begin{enumerate}
    \item
-    Advertise all MES events and activities to first year students by making class announcements, promoting the MES website, and MESsenger email list.
+    Advertise all MES events and activities to first year students by making class announcements, promoting the MES website.
    \item
     Serve on the First Year Committee (see MES Bylaws Section \ref{first-year-committee}).
    \item

--- a/Sections/11 - Services.tex
+++ b/Sections/11 - Services.tex
@@ -231,22 +231,6 @@ website.
 
 \end{enumerate}
 
-\subsection{MESsenger}
-\label{messenger}
-The MESsenger is an email list established to enhance communication to
-MES members about MES events and activities, as well as other relevant
-information that involves or is of particular interest to the
-engineering student body.
-
-\begin{enumerate}
- \item
-  The VPC is responsible for compiling a monthly newsletter of MES activities, opportunities, club//team details and related information to be sent out to the list.
- \item
-  The MESsenger will be sent out to all subscribed students on its email list, subscription is opt-in and may be cancelled at any time.
- \item
-  The integrity of the MESsenger is of the utmost importance; the list must never be abused or used for any other reason than those stated above. The privacy of all subscribers to the list must be respected.
-\end{enumerate}
-
 \subsection{DW Lounge}
 \label{dw-lounge}
 The David Wilkinson Undergraduate Engineering (DW) Lounge is for the use

--- a/Sections/Exec Portfolios/vice-president-student-life.tex
+++ b/Sections/Exec Portfolios/vice-president-student-life.tex
@@ -28,8 +28,6 @@ The Vice President, Student Life shall:
  \item
   Coordinate and organize events for Frost Week.
  \item
-  Facilitate collection of content for the MESsenger, and pass it on to VPC to send to all undergraduate engineering students on a monthly basis
- \item
   Supervise the activities and initiatives of the Program and First Year Representatives.
  \item
   Plan an end-of-semester social for all MES appointed and elected council members.


### PR DESCRIPTION
24-07-11-EM-01a

The MESsenger has been an inactive newsletter for multiple years, and should be removed from our bylaws.