### PR TITLE
[MOTION] 24-07-11 Update eligibility, timeline, and funding of the Academic Workshops

### DIFF
--- a/Sections/11 - Services.tex
+++ b/Sections/11 - Services.tex
@@ -709,19 +709,22 @@ Drain and shall be maintained by the AVPAR.
   Workshop leads shall be paid at a rate of \$27/hour, up to a maximum of 3 hours per workshop.
  \item
   Workshop leads must complete Appendix Y and submit it to the AVPAR in order to be reimbursed.
-
+ \item 
+ Workshop leads shall not be teaching assistants for courses they are organizing workshops for.
 \end{enumerate}
 
-\subsubsection{Department/Program-Society-Organized Academic
+\subsubsection{Program-Society-Organized Academic
  Workshops}
-\label{departmentprogram-society-organized-academic-workshops}
+\label{program-society-organized-academic-workshops}
 \begin{enumerate}
  \item
-  Departments may run their own academic workshops for department-specific courses. Department societies are responsible for organizing workshops and finding workshop leads, and paying them.
+  Program Societies may run their own academic workshops for department-specific courses. Program Societies are responsible for organizing workshops and finding workshop leads, and paying them.
  \item
-  Workshop leads shall be paid at a rate of \$27/hour, up to a maximum of 3 hours per workshop and 1 help session lead per workshop. Departments may send a request for more funding to the AVPAR and/or VPF if they have more than 1 lead at a help session, however extra funding is not guaranteed.
+ All Program societies shall submit for prior approval from the DoAR, at least 2 weeks prior to any eligible academic workshops which they would request funding.
  \item
-  MES department/program representatives are responsible for ensuring that their workshop leads complete Appendix Y and for submitting it to the AVPAR in order for their department/program society to be reimbursed.
+  Workshop leads shall be paid at a rate of \$27/hour, up to a maximum of 3 hours per workshop and 1 help session lead per workshop.
+ \item
+  MES Program representatives are responsible for ensuring that their workshop leads complete Appendix Y and for submitting it to the AVPAR in order for their Program Society to be reimbursed.
 \end{enumerate}
 
 \subsection{Coveralls}


### PR DESCRIPTION
24-07-11-EM-01s

- Disallow workshop leads if they are presently TAs in the course
- Require two weeks notice application to the Director of Academic Resources for a program society workshop
- Limit the number of session leads to one