### PR TITLE
[MOTION] Intramural Funding Policy Updates

### DIFF
--- a/Sections/3 - Appointed Positions.tex
+++ b/Sections/3 - Appointed Positions.tex
@@ -733,7 +733,7 @@ The Sport Coordinator(s) shall:
  \item
   Organize and maintain the collection of sports equipment rentals in the MES office.
  \item
-  Review and approve funding requests for intramural sports teams (see MES Bylaws Section \ref{intramural-funding-policy}) and forward to the VPF.
+ Promote the Intramural Funding applications, in collaboration with the VP Finance.
  \item
   Report to the DoE.
  \item

--- a/Sections/9 - Financial Policies.tex
+++ b/Sections/9 - Financial Policies.tex
@@ -296,24 +296,22 @@ by the appropriate level:
 \label{intramural-funding-policy}
 \begin{enumerate}
  \item
-  The MES will sponsor intramural sports teams composed of at least 80\% MES members. These teams shall be reimbursed up to the percentage of MES members on their roster. If the intramural budget is underperforming the VPF and Sports Coordinator(s) reserve the authority to lower the mandatory member composition to a minimum of 75\% MES members. If this happens there would be retroactive reimbursements to teams from the first semester that had already submitted their funding documents.
+  The MES will sponsor intramural sports teams composed of at least 80\% MES members. These teams shall be reimbursed up to the percentage of MES members on their roster.
  \item
   The MES will fund the cost of registration up to \$300, matching the percentage of MES members on the team, not including any required deposits.
  \item
-  To receive funding, a team must submit the following items to the Sports Coordinator(s):
+  To receive funding, a team must submit the following items to the VP Finance:
 
   \begin{enumerate}
    \item
-    A completed copy of Appendix X -- Intramurals Funding, including a full list of the team's playoff roster, including programs of study and student numbers of each team member, signed by each member of the team, and indicating the percentage of MES members.
+    A completed copy of Appendix X -- Intramurals Funding, including a full list of the team's playoff roster, including programs and levels of study, and indicating the percentage of MES members.
    \item
-    A standard expense report indicating the value of funding which appropriately reflects the percentage of MES members and the deduction of any required deposits.
-   \item
-    Copy of the receipt as proof of registration.
+    Receipt; proof of payment and registration.
   \end{enumerate}
  \item
-  The Sports Coordinator(s) shall review requests for funding to ensure they meet all requirements, and forward expense reports and receipts to the VPF.
+  The VP Finance shall review requests for funding to ensure they meet all requirements.
  \item
-  The Sports Coordinator(s) will be notified of the budget by the VPF once the budget is approved. The Sports Coordinator(s) should only approve requests within the limits of the budget.
+  The VP Finance should only approve requests within the limits of the budget.
  \item
   The funding pool is limited and may be exhausted before all teams apply. The VPF shall decide whether requests are acceptable and within the limits of the MES Budget.
 \end{enumerate}

--- a/Sections/Exec Portfolios/vice-president-finance.tex
+++ b/Sections/Exec Portfolios/vice-president-finance.tex
@@ -21,6 +21,8 @@ The Vice President, Finance shall:
  \item
   Oversee reimbursement processes from the special projects and student projects fund, in coordination with the Student Projects Coordinator(s).
  \item
+ Organize, review, and approve funding requests for intramural sports teams (see MES Bylaws Section \ref{intramural-funding-policy})
+ \item
   Be audited or reviewed by an outside accounting firm for the purpose of official statements if requested by Financial Services to receive Society fees.
  \item
   Serve on the macLAB Board of Directors (see MES Bylaws Section \ref{maclab-board-of-directors}).


### PR DESCRIPTION
25-01-30-CM-05 First Reading
25-02-13-CM-04 Second Reading

WHEREAS Intramural Funding is a set funding pool allocated each year in the MES budget

WHEREAS most of the effort of Intramural Funding is already undertaken by the VP Finance

WHEREAS the existing processing is redundant and requires multiple levels of approvals

WHEREAS Intramural Funding is administrative and the time commitment detracts from the Sports Coordinator(s) ability to execute events

WHEREAS the Winter 2025 Intramural Reimbursements have been delayed by over two months

WHEREAS Winter 2025 intramural sign-ups occur in November

BE IT RESOLVED THAT the responsibility of organizing intramural reimbursements is transferred to the VP Finance

BE IT FURTHER RESOLVED THAT intramural reimbursements for both Fall and Winter term intramurals shall happen during the Fall term

BE IT FURTHER RESOLVED THAT the following changes are made to the bylaws:

**First Reading Discussion**
Michael: I hope it does not underperform, having contingency is of importance. 
Luke: The second sentence there is for retroactive imbursements; I don't think it's a relevant criteria. 
Michael: I mean there's no harm in having it in the books. 

Tyler: How do you see this adding to the VPF portfolio?
Luke: 30-60 e-transfers, one spreadsheet formula, and now there is a financial operations team.

**Second Reading Discussion**
Michael: We talked 80% vs 75%, but why is 80% the threshold? I feel like we should keep it 80%. 
Luke: Two weeks ago, I thought you asked for 75% but now you want 80%?
Tyler: I think you mentioned this: you said it doesn't really matter as it is half a person difference. 75 to 80 or 80 to 75 is just redundant. 
Luke: Then, we can leave it at 80% as how it was. 
Michae: I think we should still support it and keep it in. Ideally, we want 80% and we can go to 75% if necessary. 
Luke: People don't apply if it's less than 80. 
