### PR TITLE
[MOTION] Coverall Policy Updates

### DIFF
--- a/Sections/11 - Services.tex
+++ b/Sections/11 - Services.tex
@@ -769,7 +769,7 @@ responsibility that comes with wearing the coverall.
    \item
     Communicating application status with Coverall Sponsors and the application status of their Coverall Event(s).
    \item
-    Maintaining a list of club executives, vetting the eligibility of Coverall Sponsor applicants, and acting as the Coverall Sponsor for Student Organization leadership.
+    Maintaining a list of club executives, vetting the eligibility of Coverall Sponsor applicants, and acting as the Coverall Sponsor in the case a Coverall Sponsor applies to purchase Coveralls for their own Coverall Event.
    \item
     Communicating application status with Coverall Applicants.
    \item
@@ -794,7 +794,7 @@ responsibility that comes with wearing the coverall.
  \item
   All Coverall Sponsors must submit a signed Coverall Sponsorship Usage Contract (Appendix Z) with their Coverall Event application.
  \item
-  Upon approval of their Coverall Event, Coverall Sponsors must still fill out the Coverall Application if they are interested in wearing their own coveralls.
+  Upon approval of their Coverall Event, Coverall Sponsors must still fill out the Coverall Application if they are interested in purchasing their own coveralls.
 
 \end{enumerate}
 \subsubsection{Coverall Events}
@@ -807,11 +807,14 @@ responsibility that comes with wearing the coverall.
  \item
   Coverall Event applications are required for all events where coveralls will be worn.
  \item
-  Coverall Events need to be resubmitted each year, even for an event with the same name and purpose.
-
+  Coverall Events need to be resubmitted each year, even for an event with the same name and purpose that was approved in a prior year.
+ \item
+  Coverall Events may be approved for either of the following purposes:
   \begin{enumerate}
    \item
-    The Coverall Sponsor for the event must be the current President, Lead, Principal Investigator, or individual of equivalent title.
+    The wearing of coveralls at the Coverall Event
+   \item
+    The purchase of coveralls, which can then be worn at the Coverall Event
   \end{enumerate}
  \item
   Examples of eligible Coverall Events include, but are not limited to:


### PR DESCRIPTION
25-01-30-CM-06 First Reading
25-02-13-CM-04 Second Reading

WHEREAS the current Coverall Policy has ambiguities

WHEREAS 11.2.3.2 and 11.2.4.4.a had conflicting definitions for the eligibility of a Coverall Sponsor

WHEREAS Coverall Events may be approved for the wearing of coveralls, but not necessarily the purchase of coveralls

BE IT RESOLVED THAT the following changes are made to the bylaws:

**First Reading Discussion**
Tyler: Are the coveralls redsuits?
Luke: These are coveralls for design comps, conferences and others. 
Tyler: So these are the redsuits?
Luke: Yes.

**Second Reading Discussion**
Tyler: Have there been any changes since the first reading? 
Alexis: No 

Michael: What are coveralls? 
Alexis: These are the coveralls that welcome week reps wear and that people wear at conferences, competitions and more.

